### PR TITLE
chore: add chrome for testing

### DIFF
--- a/web-browsers/chrome/chrome-linux64_140.zip
+++ b/web-browsers/chrome/chrome-linux64_140.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:752add52e58c9c7d7565c01c49d3058a0357e24fd518d2b842e22f3577a785fa
+size 176704551


### PR DESCRIPTION
Added Chrome for testing zip taken from here: https://googlechromelabs.github.io/chrome-for-testing/

Specifically this zip file: https://storage.googleapis.com/chrome-for-testing-public/140.0.7339.82/linux64/chrome-linux64.zip