### PR TITLE
feat: Automatic browsers and drivers download

### DIFF
--- a/.github/workflows/download-browsers.yml
+++ b/.github/workflows/download-browsers.yml
@@ -10,6 +10,7 @@ on:
         options:
           - firefox
           - chrome
+          - chrome-for-testing
           - edge
           - chromium
       version:
@@ -37,7 +38,8 @@ jobs:
                 {"browser": "firefox", "version": ""},
                 {"browser": "chrome", "version": ""},
                 {"browser": "edge", "version": ""},
-                {"browser": "chromium", "version": ""}
+                {"browser": "chromium", "version": ""},
+                {"browser": "chrome-for-testing", "version": ""},
               ]'
             )
           else
@@ -105,6 +107,9 @@ jobs:
             case "chromium":
               all_binaries = "https://snapshot.debian.org/mr/binary/chromium/"
               version = [item["version"] for item in requests.get(all_binaries).json().get("result", [])][0].split('-')[0]
+            case "chrome-for-testing":
+              url="https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json"
+              version=requests.get(url).json()['channels']['Stable']['version']
 
           with open(env_file, "a") as variables:
             variables.write(f"VERSION={version}")
@@ -163,13 +168,21 @@ jobs:
                 url="snapshot.debian.org/archive/debian/${ts}/pool/main/c/chromium/chromium_${VERSION}-1_amd64.deb"
                 driver_url="snapshot.debian.org/archive/debian/${ts}/pool/main/c/chromium/chromium-driver_${VERSION}-1_amd64.deb"
                 ;;
+              chrome-for-testing)
+                url="https://storage.googleapis.com/chrome-for-testing-public/${VERSION}/linux64/chrome-linux64.zip"
+                driver_url="https://storage.googleapis.com/chrome-for-testing-public/${VERSION}/linux64/chromedriver-linux64.zip"
+                ;;
             esac
                 
             echo "Download browser..."
-            wget -O ${{ matrix.browser }}.deb $url
-            echo "Zipping package..."
-            mkdir -p web-browsers/${{ matrix.browser }}/${VERSION}
-            zip -j web-browsers/${{ matrix.browser }}/${VERSION}/${{ matrix.browser }}.zip ${{ matrix.browser }}.deb
+            if [ '${{ matrix.browser }}' != 'chrome-for-testing' ]; then
+              wget -O ${{ matrix.browser }}.deb $url
+              echo "Zipping package..."
+              mkdir -p web-browsers/${{ matrix.browser }}/${VERSION}
+              zip -j web-browsers/${{ matrix.browser }}/${VERSION}/${{ matrix.browser }}.zip ${{ matrix.browser }}.deb
+            else
+              wget -P web-browsers/${{ matrix.browser }}/${VERSION} $url
+            fi
 
             echo "Download driver..."
             wget -P web-browsers/${{ matrix.browser }}/${VERSION} $driver_url

--- a/.github/workflows/download-browsers.yml
+++ b/.github/workflows/download-browsers.yml
@@ -110,7 +110,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: "eu-central-1"
-          role-to-assume: "arn:aws:iam::332405224602:role/iog-catalyst-storage-uploader"
+          role-to-assume: "arn:aws:iam::332405224602:role/ci"
 
       - name: Download from repos and upload into S3
         run: |

--- a/.github/workflows/download-browsers.yml
+++ b/.github/workflows/download-browsers.yml
@@ -20,9 +20,6 @@ on:
   schedule:
     - cron: "0 10 * * MON" #UTC time 
 
-permissions:
-  contents: write
-
 jobs:
   generate-matrix:
     runs-on: ubuntu-latest
@@ -109,35 +106,28 @@ jobs:
         env:
           BROWSER: ${{ matrix.browser }}
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Login to AWS
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          aws-region: "eu-central-1"
+          role-to-assume: "arn:aws:iam::332405224602:role/iog-catalyst-storage-uploader"
 
-      - name: Configure Git
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Enable Git LFS
-        run: |
-          git lfs install
-          git lfs track "*.zip"
-          git add .gitattributes
-          git commit -m "Configure Git LFS" || echo "LFS already configured"
-
-      - name: Create branch and push
+      - name: Download from repos and upload into S3
         run: |
           set -e
-          BRANCH="${{ matrix.browser }}-${VERSION}"
+          BUCKET_NAME="iog-catalyst-storage"
+ 
+          versions=$(aws s3api list-objects-v2 \
+            --bucket "$BUCKET_NAME" \
+            --prefix "${{ matrix.browser }}/" \
+            --delimiter "/" \
+            --query "CommonPrefixes[].Prefix" \
+            --output text)
 
-          echo "Checking branch $BRANCH..."
-          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            echo "$BRANCH branch already exists. Skipping."
-            exit 0
+          if echo "$versions" | grep -q "${{ matrix.browser }}/${VERSION}/"; then 
+            echo "${VERSION} already exists. Skipping."
+            exit 0 
           fi
-          git checkout -b "$BRANCH"
           
           if [[ "${{ matrix.browser }}" = "firefox" || "${{ matrix.browser }}" = "chromium" ]]; then ARCH_LIST="amd64 aarch64"; else ARCH_LIST="amd64"; fi
 
@@ -175,28 +165,24 @@ jobs:
             esac
             
             deb_arch=$([ "$ARCH" = "aarch64" ] && echo "arm64" || echo "amd64")
-            mkdir -p web-browsers/${{ matrix.browser }}/${VERSION}
+            mkdir -p ${{ matrix.browser }}/${VERSION}
             
             echo "Downloading browser..."
             if [ '${{ matrix.browser }}' != 'chrome-for-testing' ]; then
-              wget -P web-browsers/${{ matrix.browser }}/${VERSION} -O "${{ matrix.browser }}_${deb_arch}.deb" "$url"
-              zip -j "web-browsers/${{ matrix.browser }}/${VERSION}/${{ matrix.browser }}_${deb_arch}.zip" "${{ matrix.browser }}_${deb_arch}.deb"
+              wget -P ${{ matrix.browser }}/${VERSION} -O "${{ matrix.browser }}_${deb_arch}.deb" "$url"
+              zip -j "${{ matrix.browser }}/${VERSION}/${{ matrix.browser }}_${deb_arch}.zip" "${{ matrix.browser }}_${deb_arch}.deb"
               rm -f "${{ matrix.browser }}_${deb_arch}.deb"
             else
-              wget -P "web-browsers/${{ matrix.browser }}/${VERSION}" "$url"
+              wget -P "${{ matrix.browser }}/${VERSION}" "$url"
             fi
             
             echo "Downloading driver..."
-            wget -P "web-browsers/${{ matrix.browser }}/${VERSION}" "$driver_url"
+            wget -P "${{ matrix.browser }}/${VERSION}" "$driver_url"
             
             if [ '${{ matrix.browser }}' == 'chromium' ]; then
-              find . -type f -iname "*-driver*${deb_arch}*" -print0 | xargs -0 zip -j web-browsers/${{ matrix.browser }}/${VERSION}/${{ matrix.browser }}-driver-${deb_arch}.zip
-              rm -f web-browsers/${{ matrix.browser }}/${VERSION}/*${deb_arch}.deb
+              find . -type f -iname "*-driver*${deb_arch}*" -print0 | xargs -0 zip -j ${{ matrix.browser }}/${VERSION}/${{ matrix.browser }}-driver-${deb_arch}.zip
+              rm -f ${{ matrix.browser }}/${VERSION}/*${deb_arch}.deb
             fi
           done
-          
-          git add web-browsers/${{ matrix.browser }}/${VERSION}
-          git commit -m "Add ${{ matrix.browser }} ${VERSION} package and driver"
-          git push origin "$BRANCH"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+          aws s3 cp ${{ matrix.browser }}/${VERSION} s3://${BUCKET_NAME}/${{ matrix.browser }}/${VERSION} --recursive

--- a/.github/workflows/download-browsers.yml
+++ b/.github/workflows/download-browsers.yml
@@ -39,7 +39,7 @@ jobs:
                 {"browser": "chrome", "version": ""},
                 {"browser": "edge", "version": ""},
                 {"browser": "chromium", "version": ""},
-                {"browser": "chrome-for-testing", "version": ""},
+                {"browser": "chrome-for-testing", "version": ""}
               ]'
             )
           else
@@ -49,8 +49,6 @@ jobs:
               ]'
             )
           fi
-          
-          # Use a heredoc-style output block (avoids parsing errors)
           echo "matrix<<EOF" >> $GITHUB_OUTPUT
           echo "$MATRIX_JSON" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
@@ -65,13 +63,9 @@ jobs:
       - name: Check version
         id: need_latest
         run: |
-          echo "Running for: ${{ matrix.browser }}"
-          echo "Checking if version has been set"
-          if [ -z ${{ matrix.version }} ]; then
-            echo "Version is empty. Get latest version"
+          if [ -z "${{ matrix.version }}" ]; then
             echo "get_latest=true" >> $GITHUB_OUTPUT
           else
-            echo "Version: ${{ matrix.version }}"
             echo "get_latest=false" >> $GITHUB_OUTPUT
             echo "VERSION=${{ matrix.version }}" >> $GITHUB_ENV
           fi
@@ -91,6 +85,7 @@ jobs:
         id: latest_version
         run: |
           import requests, os
+
           browser = os.environ.get("BROWSER")
           env_file = os.getenv('GITHUB_ENV')
 
@@ -99,23 +94,20 @@ jobs:
               url = "https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/stable/versions"
               version = requests.get(url).json()["versions"][0]["version"]
             case "firefox":
-              url = "https://product-details.mozilla.org/1.0/firefox_versions.json"
-              version = requests.get(url).json()["LATEST_FIREFOX_VERSION"]
+              version = requests.get("https://snapshot.debian.org/mr/binary/firefox-esr/").json()["result"][0]["version"]
             case "edge":
               url = "https://edgeupdates.microsoft.com/api/products"
               version = next(filter(lambda p: p.get("Product") == "Stable", requests.get(url).json()))['Releases'][0]['ProductVersion']
             case "chromium":
-              all_binaries = "https://snapshot.debian.org/mr/binary/chromium/"
-              version = [item["version"] for item in requests.get(all_binaries).json().get("result", [])][0].split('-')[0]
+              version = requests.get("https://snapshot.debian.org/mr/binary/chromium/").json()["result"][0]["version"].split('-')[0]
             case "chrome-for-testing":
               url="https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json"
               version=requests.get(url).json()['channels']['Stable']['version']
-
           with open(env_file, "a") as variables:
             variables.write(f"VERSION={version}")
         shell: python
         env:
-          BROWSER: ${{ inputs.browser }}
+          BROWSER: ${{ matrix.browser }}
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -137,65 +129,74 @@ jobs:
 
       - name: Create branch and push
         run: |
+          set -e
           BRANCH="${{ matrix.browser }}-${VERSION}"
 
           echo "Checking branch $BRANCH..."
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            echo "$BRANCH branch already exists. Skip."
-          else
-            echo "Creating branch and download deb"
-            git checkout -b "$BRANCH"
-            
+            echo "$BRANCH branch already exists. Skipping."
+            exit 0
+          fi
+          git checkout -b "$BRANCH"
+          
+          if [[ "${{ matrix.browser }}" = "firefox" || "${{ matrix.browser }}" = "chromium" ]]; then ARCH_LIST="amd64 aarch64"; else ARCH_LIST="amd64"; fi
+
+          for ARCH in $ARCH_LIST; do
+            echo "Downloading for $ARCH..."
             case ${{ matrix.browser }} in
               chrome)
                 url="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${VERSION}-1_amd64.deb"
                 driver_url="https://storage.googleapis.com/chrome-for-testing-public/${VERSION}/linux64/chromedriver-linux64.zip"
                 ;;
               firefox)
-                url="https://ftp.mozilla.org/pub/firefox/releases/${VERSION}/linux-x86_64/en-US/firefox-${VERSION}.deb"
-
-                echo "As for now it downloads latest geckodriver"
+                deb_arch=$([ "$ARCH" = "aarch64" ] && echo "arm64" || echo "amd64")
+                ts=$(curl -s "https://snapshot.debian.org/mr/binary/firefox-esr/${VERSION}/binfiles?fileinfo=1" \
+                  | jq -r ".fileinfo[ .result[] | select(.architecture==\"${deb_arch}\") | .hash ][0].first_seen")
+                url="snapshot.debian.org/archive/debian/${ts}/pool/main/f/firefox-esr/firefox-esr_${VERSION}_${deb_arch}.deb"
                 driver_latest=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r .tag_name)
-                driver_url="https://github.com/mozilla/geckodriver/releases/download/$driver_latest/geckodriver-${driver_latest}-linux64.tar.gz"
+                deb_arch=$([ "$ARCH" = "aarch64" ] && echo "-aarch64" || echo "64")
+                driver_url="https://github.com/mozilla/geckodriver/releases/download/$driver_latest/geckodriver-${driver_latest}-linux${deb_arch}.tar.gz"
                 ;;
               edge)
                 url="https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_${VERSION}-1_amd64.deb"
                 driver_url="https://msedgedriver.microsoft.com/${VERSION}/edgedriver_linux64.zip"
                 ;;
               chromium)
+                deb_arch=$([ "$ARCH" = "aarch64" ] && echo "arm64" || echo "amd64")
                 ts=$(curl -s "https://snapshot.debian.org/mr/binary/chromium/${VERSION}-1/binfiles?fileinfo=1" \
-                 | jq -r '.fileinfo[ .result[] | select(.architecture=="amd64") | .hash ][0].first_seen')
-                url="snapshot.debian.org/archive/debian/${ts}/pool/main/c/chromium/chromium_${VERSION}-1_amd64.deb"
-                driver_url="snapshot.debian.org/archive/debian/${ts}/pool/main/c/chromium/chromium-driver_${VERSION}-1_amd64.deb"
+                  | jq -r ".fileinfo[ .result[] | select(.architecture==\"${deb_arch}\") | .hash ][0].first_seen")
+                url="snapshot.debian.org/archive/debian/${ts}/pool/main/c/chromium/chromium_${VERSION}-1_${deb_arch}.deb"
+                driver_url="snapshot.debian.org/archive/debian/${ts}/pool/main/c/chromium/chromium-driver_${VERSION}-1_${deb_arch}.deb"
                 ;;
               chrome-for-testing)
                 url="https://storage.googleapis.com/chrome-for-testing-public/${VERSION}/linux64/chrome-linux64.zip"
                 driver_url="https://storage.googleapis.com/chrome-for-testing-public/${VERSION}/linux64/chromedriver-linux64.zip"
                 ;;
             esac
-                
-            echo "Download browser..."
+            
+            deb_arch=$([ "$ARCH" = "aarch64" ] && echo "arm64" || echo "amd64")
+            mkdir -p web-browsers/${{ matrix.browser }}/${VERSION}
+            
+            echo "Downloading browser..."
             if [ '${{ matrix.browser }}' != 'chrome-for-testing' ]; then
-              wget -O ${{ matrix.browser }}.deb $url
-              echo "Zipping package..."
-              mkdir -p web-browsers/${{ matrix.browser }}/${VERSION}
-              zip -j web-browsers/${{ matrix.browser }}/${VERSION}/${{ matrix.browser }}.zip ${{ matrix.browser }}.deb
+              wget -P web-browsers/${{ matrix.browser }}/${VERSION} -O "${{ matrix.browser }}_${deb_arch}.deb" "$url"
+              zip -j "web-browsers/${{ matrix.browser }}/${VERSION}/${{ matrix.browser }}_${deb_arch}.zip" "${{ matrix.browser }}_${deb_arch}.deb"
+              rm -f "${{ matrix.browser }}_${deb_arch}.deb"
             else
-              wget -P web-browsers/${{ matrix.browser }}/${VERSION} $url
+              wget -P "web-browsers/${{ matrix.browser }}/${VERSION}" "$url"
             fi
-
-            echo "Download driver..."
-            wget -P web-browsers/${{ matrix.browser }}/${VERSION} $driver_url
+            
+            echo "Downloading driver..."
+            wget -P "web-browsers/${{ matrix.browser }}/${VERSION}" "$driver_url"
             
             if [ '${{ matrix.browser }}' == 'chromium' ]; then
-              find . -type f -iname "*-driver*" -print0 | xargs -0 zip -j web-browsers/${{ matrix.browser }}/${VERSION}/${{ matrix.browser }}-driver.zip
-              rm -f web-browsers/${{ matrix.browser }}/${VERSION}/*.deb
+              find . -type f -iname "*-driver*${deb_arch}*" -print0 | xargs -0 zip -j web-browsers/${{ matrix.browser }}/${VERSION}/${{ matrix.browser }}-driver-${deb_arch}.zip
+              rm -f web-browsers/${{ matrix.browser }}/${VERSION}/*${deb_arch}.deb
             fi
-
-            # Commit and push
-            git add web-browsers/${{ matrix.browser }}/${VERSION}
-            git commit -m "Add ${{ matrix.browser }} ${VERSION} package and driver"
-            git push origin "$BRANCH"
-          fi
+          done
+          
+          git add web-browsers/${{ matrix.browser }}/${VERSION}
+          git commit -m "Add ${{ matrix.browser }} ${VERSION} package and driver"
+          git push origin "$BRANCH"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/download-browsers.yml
+++ b/.github/workflows/download-browsers.yml
@@ -1,10 +1,10 @@
-name: Download browsers packages
+name: Download browsers and drivers packages
 
 on:
   workflow_dispatch:
     inputs:
       browser:
-        description: "Select browser or driver"
+        description: "Select browser and driver"
         required: true
         type: choice
         options:

--- a/.github/workflows/download-browsers.yml
+++ b/.github/workflows/download-browsers.yml
@@ -1,0 +1,188 @@
+name: Download browsers packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      browser:
+        description: "Select browser or driver"
+        required: true
+        type: choice
+        options:
+          - firefox
+          - chrome
+          - edge
+          - chromium
+      version:
+        description: "Optional: specify version (leave empty for latest)"
+        required: false
+        default: ""
+  schedule:
+    - cron: "0 10 * * MON" #UTC time 
+
+permissions:
+  contents: write
+
+jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - name: Generate matrix JSON
+        id: generate
+        run: |
+          if [ '${{ github.event_name }}' == 'schedule' ]; then
+            MATRIX_JSON=$(jq -n \
+              '[
+                {"browser": "firefox", "version": ""},
+                {"browser": "chrome", "version": ""},
+                {"browser": "edge", "version": ""},
+                {"browser": "chromium", "version": ""}
+              ]'
+            )
+          else
+            MATRIX_JSON=$(jq -n \
+              '[
+                {"browser": "${{ inputs.browser }}", "version": "${{ inputs.version }}"}
+              ]'
+            )
+          fi
+          
+          # Use a heredoc-style output block (avoids parsing errors)
+          echo "matrix<<EOF" >> $GITHUB_OUTPUT
+          echo "$MATRIX_JSON" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          
+  download:
+    needs: generate-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - name: Check version
+        id: need_latest
+        run: |
+          echo "Running for: ${{ matrix.browser }}"
+          echo "Checking if version has been set"
+          if [ -z ${{ matrix.version }} ]; then
+            echo "Version is empty. Get latest version"
+            echo "get_latest=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version: ${{ matrix.version }}"
+            echo "get_latest=false" >> $GITHUB_OUTPUT
+            echo "VERSION=${{ matrix.version }}" >> $GITHUB_ENV
+          fi
+
+      - name: Set up Python
+        if: steps.need_latest.outputs.get_latest == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        if: steps.need_latest.outputs.get_latest == 'true'
+        run: pip install requests
+
+      - name: Get latest versions
+        if: steps.need_latest.outputs.get_latest == 'true'
+        id: latest_version
+        run: |
+          import requests, os
+          browser = os.environ.get("BROWSER")
+          env_file = os.getenv('GITHUB_ENV')
+
+          match browser:
+            case "chrome":
+              url = "https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/stable/versions"
+              version = requests.get(url).json()["versions"][0]["version"]
+            case "firefox":
+              url = "https://product-details.mozilla.org/1.0/firefox_versions.json"
+              version = requests.get(url).json()["LATEST_FIREFOX_VERSION"]
+            case "edge":
+              url = "https://edgeupdates.microsoft.com/api/products"
+              version = next(filter(lambda p: p.get("Product") == "Stable", requests.get(url).json()))['Releases'][0]['ProductVersion']
+            case "chromium":
+              all_binaries = "https://snapshot.debian.org/mr/binary/chromium/"
+              version = [item["version"] for item in requests.get(all_binaries).json().get("result", [])][0].split('-')[0]
+
+          with open(env_file, "a") as variables:
+            variables.write(f"VERSION={version}")
+        shell: python
+        env:
+          BROWSER: ${{ inputs.browser }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Enable Git LFS
+        run: |
+          git lfs install
+          git lfs track "*.zip"
+          git add .gitattributes
+          git commit -m "Configure Git LFS" || echo "LFS already configured"
+
+      - name: Create branch and push
+        run: |
+          BRANCH="${{ matrix.browser }}-${VERSION}"
+
+          echo "Checking branch $BRANCH..."
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "$BRANCH branch already exists. Skip."
+          else
+            echo "Creating branch and download deb"
+            git checkout -b "$BRANCH"
+            
+            case ${{ matrix.browser }} in
+              chrome)
+                url="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${VERSION}-1_amd64.deb"
+                driver_url="https://storage.googleapis.com/chrome-for-testing-public/${VERSION}/linux64/chromedriver-linux64.zip"
+                ;;
+              firefox)
+                url="https://ftp.mozilla.org/pub/firefox/releases/${VERSION}/linux-x86_64/en-US/firefox-${VERSION}.deb"
+
+                echo "As for now it downloads latest geckodriver"
+                driver_latest=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r .tag_name)
+                driver_url="https://github.com/mozilla/geckodriver/releases/download/$driver_latest/geckodriver-${driver_latest}-linux64.tar.gz"
+                ;;
+              edge)
+                url="https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_${VERSION}-1_amd64.deb"
+                driver_url="https://msedgedriver.microsoft.com/${VERSION}/edgedriver_linux64.zip"
+                ;;
+              chromium)
+                ts=$(curl -s "https://snapshot.debian.org/mr/binary/chromium/${VERSION}-1/binfiles?fileinfo=1" \
+                 | jq -r '.fileinfo[ .result[] | select(.architecture=="amd64") | .hash ][0].first_seen')
+                url="snapshot.debian.org/archive/debian/${ts}/pool/main/c/chromium/chromium_${VERSION}-1_amd64.deb"
+                driver_url="snapshot.debian.org/archive/debian/${ts}/pool/main/c/chromium/chromium-driver_${VERSION}-1_amd64.deb"
+                ;;
+            esac
+                
+            echo "Download browser..."
+            wget -O ${{ matrix.browser }}.deb $url
+            echo "Zipping package..."
+            mkdir -p web-browsers/${{ matrix.browser }}/${VERSION}
+            zip -j web-browsers/${{ matrix.browser }}/${VERSION}/${{ matrix.browser }}.zip ${{ matrix.browser }}.deb
+
+            echo "Download driver..."
+            wget -P web-browsers/${{ matrix.browser }}/${VERSION} $driver_url
+            
+            if [ '${{ matrix.browser }}' == 'chromium' ]; then
+              find . -type f -iname "*-driver*" -print0 | xargs -0 zip -j web-browsers/${{ matrix.browser }}/${VERSION}/${{ matrix.browser }}-driver.zip
+              rm -f web-browsers/${{ matrix.browser }}/${VERSION}/*.deb
+            fi
+
+            # Commit and push
+            git add web-browsers/${{ matrix.browser }}/${VERSION}
+            git commit -m "Add ${{ matrix.browser }} ${VERSION} package and driver"
+            git push origin "$BRANCH"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow for automatically downloading deb packages for browsers and drivers with the amd64 architecture (may add aarch64 support for browsers that support this architecture).

The pipeline can be launched manually and on a schedule (every Monday at 10 AM UTC time).
When starting manually, you can specify the browser version you want to download or leave the field empty to download the latest version.

After the pipeline is completed, he will create a branch in the repository of the form chrome-xxx.xx.xxx which will contain zip archives with deb packages of the browser and driver:

<img width="511" height="460" alt="image" src="https://github.com/user-attachments/assets/e303d0ce-20b5-4c83-a0c9-2271b0492311" />

<img width="956" height="350" alt="image" src="https://github.com/user-attachments/assets/58f3a0b0-7897-448a-8da2-a514ddc2a177" />

<img width="1166" height="205" alt="image" src="https://github.com/user-attachments/assets/54997814-8cd1-453e-ae9c-782add551a13" />

At the moment, the workflow does not support automatic cleanup, so from time to time we will have to manually delete unused branches.

It is also possible to store zip archives as a releases.

This PR is open for discussion on several points:
- Should I store the zip archives the same way it is done now (separate branch for each browser version) or store the archives in different folders (browser/version) in the main branch or in releases or somewhere else?
- Is aarch64 support required?
- Which browsers should be supported (currently chrome, chromium, edge, firefox)?
- How often should the workflow run (currently every Monday in the morning)?
- Should we be notified somehow if the pipeline crashes and if a new version of the browser appears?
- Do we need to somehow track how big this repository has become?

Related issue: https://github.com/input-output-hk/catalyst-storage/issues/1
Related PR: https://github.com/input-output-hk/catalyst-ci/pull/458